### PR TITLE
SHG-contributors: Update contributors for initial commit

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1854,3 +1854,5 @@
 -[@HBenzaoui](https://github.com/HBenzaoui)
 
 -[@unknownaloy](https://github.com/unknownaloy)
+
+-[@AmerPandzo](https://github.com/AmerPandzo)


### PR DESCRIPTION
This is the initial commit to start for Hacktoberfest 

#hacktoberfest. 