### PR TITLE
Fixed retozon (line 2055) formatting

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2052,7 +2052,7 @@
 
 -[@agaogao](https://github.com/agaogao)
 
--[@retozon] (https://github.com/retozon)
+-[@retozon](https://github.com/retozon)
 
 -[@iprelec](https://github.com/iprelec)
 


### PR DESCRIPTION
Removed space so that Retozon's name will render properly as a hyperlink