### PR TITLE
Add Kong Ou to Contributors list

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7312,4 +7312,6 @@
 
 -[@KMozz](https://github.com/KMozz)
 
--[@sgmalloy](https://https://github.com/sgmalloy/)
+-[@sgmalloy](https//github.com/sgmalloy/)
+
+-[@KongOU](https://github.com/KongOU/)


### PR DESCRIPTION
I've added my name to Contributors list
and delete double `https://` on line 7315:

From
`-@sgmalloy](https://https://github.com/sgmalloy/)`
to this
`-[@sgmalloy](https//github.com/sgmalloy/)`