### PR TITLE
Update and fix CONTRIBUTORS.md for @adinautiyal to be linkable and clickable

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,7 +20,7 @@
 
 -[@rajindersingh751](https://github.com/rajindersingh751)
 
--[@adinautiyal](htpps://github.com/adinautiyal)
+-[@adinautiyal](https://github.com/adinautiyal)
 
 -[@menNsloo](https://github.com/menNsloo)
 


### PR DESCRIPTION
 I changed this -[@adinautiyal](htpps://github.com/adinautiyal) to -[@adinautiyal](https://github.com/adinautiyal) in order to make @adinautiyal's link linkable and clickable.

~ @SamirJouni

Please merge this pull request, it would be very much appreciated to help the ZTM Community. 👍 