### PR TITLE
removed/readded myself to contributors list due to merged github acco…

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -28319,8 +28319,6 @@
 
 -[@ab85hishek](https://github.com/ab85hishek/)
 
--[@amcodin](https://github.com/amcodin)
-
 -[@Dewudev](https://github.com/Dewudev)
 
 -[@brucelinsyd](https://github.com/brucelinsyd)
@@ -28784,3 +28782,5 @@
 -[@tnguyen0393](https://github.com/tnguyen0393)
 
 -[@savvasg35](https://github.com/Savvasg35)
+
+-[@amcodin](https://github.com/amcodin)


### PR DESCRIPTION
I had an old account for GitHub and I merged my new account into the old account. I had done this pull request previously in the account that got merged. I still have the same username, so I just moved my username from where it was to the end of the contributor's file. I'm re-doing this so I can get a new invitation to the ZTM organization, because since I merged my two GitHub accounts I lost my ZTM membership. I appreciate your time. Thanks! @SamirJouni 
