### PR TITLE
Updating broken link to ZTM Code of Conduct from

### DIFF
--- a/Get_Started.md
+++ b/Get_Started.md
@@ -19,7 +19,7 @@ Along with learning new skills, you will also gain experience on projects you ca
 ## Option 1: Join a project
 Joining a project is pretty simple, checkout the [current projects](https://github.com/zero-to-mastery) and find one you would like to participate in. Check out the project README in its repo as it will have a guide on how to get started!
 
-**Please note:** Whilst working on any project in the Zero To Mastery community, you must adhere to our code of conduct, which can be found [here](https://github.com/zero-to-mastery/start-here-guidelines/blob/master/CODE_OF_CONDUCT.md)
+**Please note:** Whilst working on any project in the Zero To Mastery community, you must adhere to our code of conduct, which can be found [here](https://github.com/zero-to-mastery/CodeofConduct)
 
 ## Option 2: Create a project
 We are always on the look out for new and exciting project to add to Zero to Mastery for you all to collaborate on! If you think you have a new and exciting project/idea the community would love to get involved in, here is the process for getting it listed:
@@ -32,7 +32,7 @@ We are always on the look out for new and exciting project to add to Zero to Mas
 In order to ensure that students hard work and time are not exploited, there are a couple of rules that will need to be followed for any project:
 - The project repo and discussion channels, will be hosted under the Zero To Mastery Github organization/Discord Server
 - The project must use the [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/)
-- The project must contain and adhere to the `code of conduct` guide found [here](https://github.com/zero-to-mastery/start-here-guidelines/blob/master/CODE_OF_CONDUCT.md)
+- The project must contain and adhere to the `code of conduct` guide found [here](https://github.com/zero-to-mastery/CodeofConduct)
 
 ## Current Projects
 You can view all current projects [here](https://github.com/zero-to-mastery) or you can view the specific #current-projects channel in our Discord Community that gives you a little more detail on each project.


### PR DESCRIPTION
In the Get_Started.md file, link to the code of conduct at "https://github.com/zero-to-mastery/start-here-guidelines/blob/master/CODE_OF_CONDUCT.md" leads to 404 error. 

Found the Code of Conduct file at "https://github.com/zero-to-mastery/CodeofConduct" and updated Get_Started.md with this link. 

Other links in Get_Started.md appear to be working as intended. 