### PR TITLE
Another update

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -29992,4 +29992,4 @@
 
 -[@ffmkx215](https://github.com/ffmkx215/)
 
--[@hbostoniii](https://githup.com/hbostoniii)
+-[hbostoniii](https://github.com/hbostoniii)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -29992,4 +29992,4 @@
 
 -[@ffmkx215](https://github.com/ffmkx215/)
 
--[hbostoniii](https://github.com/hbostoniii)
+-[@hbostoniii](https://github.com/hbostoniii)


### PR DESCRIPTION
I misspelled the link to my GitHub profile on my last pull request and then accidentally deleted the @ symbol again. I've updated with the changes and it should be good now. @razorlegacy @tigerlight @dimor @dhsgisc @chrischandler 