### PR TITLE
adding etorres-revature as a contributor for open source

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3285,3 +3285,5 @@
 - [@laurana88](https://github.com/laurana88)
 
 -[@19millionac](https://github.com/19millionac)
+
+-[@etorres-revature](https://github.com/etorres-revature)


### PR DESCRIPTION
Adding Eric D. Torres' Github username (etorres-revature) in the contributor file as an open source contributor