### PR TITLE
Removed quotation marks

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4616,14 +4616,14 @@
 
 - [@colejbodine](https://github.com/colejbodine/)
 
-- [@EncryptedAsimov]('https://github.com/EncryptedAsimov')
+- [@EncryptedAsimov](https://github.com/EncryptedAsimov)
 
-- [@rarefiction]('https://github.com/rarefiction')
+- [@rarefiction](https://github.com/rarefiction)
 
-- [@Sagar231]('https://github.com/Sagar231/')
+- [@Sagar231](https://github.com/Sagar231/)
 
-- [@ahlgren1234]('https://github.com/ahlgren1234/')
+- [@ahlgren1234](https://github.com/ahlgren1234/)
 
-- [@Yashaswini278]('https://github.com/Yashaswini278/')
+- [@Yashaswini278](https://github.com/Yashaswini278/)
 
 - [@novasgit](https://github.com/novasgit/)


### PR DESCRIPTION
Removed quotation marks wrapping 5 users' GitHub links in order to activate hypertext.