### PR TITLE
Remove extra spaces resulting in Errors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1948,18 +1948,18 @@
 
 -[@nahrinoda](https://github.com/nahrinoda)
 
--[@duanemitchell] (https://github.com/duanemitchell)
+-[@duanemitchell](https://github.com/duanemitchell)
 
--[@coryjerni] (https://github.com/coryjerni)
+-[@coryjerni](https://github.com/coryjerni)
 
--[@lunkanstifis] (https://github.com/lunkanstifis)
+-[@lunkanstifis](https://github.com/lunkanstifis)
 
--[@shirshak89] (https://github.com/shirshak89)
+-[@shirshak89](https://github.com/shirshak89)
 
--[@abdrahmansoltan] (https://github.com/abdrahmansoltan)
+-[@abdrahmansoltan](https://github.com/abdrahmansoltan)
 
--[@chanjook1m] (https://github.com/chanjook1m/)
+-[@chanjook1m](https://github.com/chanjook1m/)
 
--[@faisalibal33] (https://github.com/faisalibal33)
+-[@faisalibal33](https://github.com/faisalibal33)
 
--[@sukanta1991] (https://github.com/sukanta1991)
+-[@sukanta1991](https://github.com/sukanta1991)


### PR DESCRIPTION
Remove spaces from Contributor.md resulting in link error for user names.
Testing by creating a new fork and raising a PR to validate the pipeline errors.