### PR TITLE
At 2281->removed space after [username]

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2278,7 +2278,7 @@
 
 - [@An2ans](https://github.com/An2ans)
 
-- [@Smallz97] (https://github.com/Smallz97)
+- [@Smallz97](https://github.com/Smallz97)
 
 - [@candebarcelo](https://github.com/candebarcelo)
 


### PR DESCRIPTION
Hello. Dear Maintainers. Extra Space between username and link is removed to avoid conflict and to maintain it properly. 
Have A Great Day.