### PR TITLE
correct markdown bullet formatting for last 6 entries

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2432,14 +2432,14 @@
 
 - [@Sayed-Husain](https://github.com/Sayed-Husain)
 
--[@catbirdseatio](https://github.com/catbirdseatio)
+- [@catbirdseatio](https://github.com/catbirdseatio)
 
--[@joberbr](https://github.com/joberbr)
+- [@joberbr](https://github.com/joberbr)
 
--[@hitansh29](https://github.com/hitansh29)
+- [@hitansh29](https://github.com/hitansh29)
 
--[@nelson2411](https://github.com/nelson2411)
+- [@nelson2411](https://github.com/nelson2411)
 
--[@jareddyck](https://github.com/jareddyck)
+- [@jareddyck](https://github.com/jareddyck)
 
--[@pranav1597](https://github.com/pranav1597)
+- [@pranav1597](https://github.com/pranav1597)


### PR DESCRIPTION
last few lines for contributers were not showing correctly as bulleted list because space was not entered after hyphen.
I've corrected.