### PR TITLE
I’ve enabled two-factor authentication on GitHub

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -127,4 +127,4 @@
 -[@MarcoM0404](https://github.com/MarcoM0404)
 
 -[@hakedo](https://github.com/hakedo)
--[@anubhav-negi](https://github.com/starlove54)s
+-[@anubhav-negi](https://github.com/starlove54)


### PR DESCRIPTION
Hi @aneagoie, 

I’ve enabled two-factor authentication on GitHub, please restore my membership in the ZTM organization.
My name was already on the list, the change I made was a mistake made by the last person who listed their account. 

Thank you,
Aurelian