### PR TITLE
Making my name a clickable link and moving it to the next line

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -410,4 +410,5 @@
 -[@djaferimehmed](https://github.com/djaferimehmed)
 
 -[@Sudarshan-Parthasarathy](https://github.com/Sudarshan-Parthasarathy)
+
 -[@brudevtek](https://github.com/brudevtek/)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -410,4 +410,4 @@
 -[@djaferimehmed](https://github.com/djaferimehmed)
 
 -[@Sudarshan-Parthasarathy](https://github.com/Sudarshan-Parthasarathy)
--[@brudevtek] (https://github.com/brudevtek)
+-[@brudevtek](https://github.com/brudevtek/)


### PR DESCRIPTION
After the previous PR, I realized my name on the contributors' list was not a clickable link and it was on the same line as the previous contributors. These are commits to fix it.