### PR TITLE
Edit URL on hyperlink for profile

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6468,7 +6468,7 @@
 
 - [@Rosiaz](https://github.com/Rosiaz)
 
-- [@Rossbrown](https:/github.com/ross-brown)
+- [@Rossbrown](https://github.com/ross-brown)
 
 - [@Rosskovt](https://github.com/rosskovt)
 


### PR DESCRIPTION
Made a typo on my github URL when adding name to contributor list. 