### PR TITLE
Updated my contributor profile, ChrisMerinoDev, to clickable Link

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -366,7 +366,7 @@
 
 - [@Janardhanjayanth](https://github.com/JanardhanJayanthxhd)
 
-- [@ChrisMerinoDev] (https://github.com/ChrisMerinoDev)
+- [@ChrisMerinoDev](https://github.com/ChrisMerinoDev)
 
 - [@Javidveg](https://github.com/javidVeg)
 


### PR DESCRIPTION
I already had my name on the Contributors File, but I had a space in between "ChrisMerinoDev(space) (GithubURL)".
Now it is fixed. :)