### PR TITLE
Add eybmits to contributors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1540,6 +1540,8 @@
 
 - [@Ekecolin](https://github.com/ekecolin)
 
+- [@eybmits](https://github.com/eybmits)
+
 - [@Eldaar](https://github.com/eldaar)
 
 - [@Elegbedeyusuf33Debug](https://github.com/elegbedeyusuf33-debug)


### PR DESCRIPTION
Adds @eybmits to the CONTRIBUTORS list following the repository guide.

Validation: reviewed the single-entry CONTRIBUTORS.md diff.