### PR TITLE
Add Minato95-ayu to contributors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -522,6 +522,8 @@
 
 - [@Arelixdev](https://github.com/arelixdev)
 
+- [@Minato95-ayu](https://github.com/Minato95-ayu)
+
 - [@Arellanoluis](https://github.com/arellanoluis)
 
 - [@Arichylton](https://github.com/arichylton)


### PR DESCRIPTION
Adds Minato95-ayu to the contributors list as part of the open-source practice workflow.