### PR TITLE
Feature/contributors page

### DIFF
--- a/.github/workflows/generate-page.yaml
+++ b/.github/workflows/generate-page.yaml
@@ -1,21 +1,21 @@
 name: 'Generate Contributors Jobs'
 
 on:
-  pull_request:
-    types:
-      - closed
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
 
 jobs:
-  if_merged:
-    if: github.event.pull_request.merged == true
+  build:
     runs-on: ubuntu-latest
 
     steps:
-      - run: |
-          echo "merging"
-      - uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.pull_request.base.ref }}
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
       - name: Install Python
         uses: actions/setup-python@v7
@@ -23,26 +23,33 @@ jobs:
           python-version: '3.13' 
 
 
-      - name: Generate conrtibutors page
+      - name: Generate contributors page
         run: python generate_page.py
 
 
       - name: Check generated index.html
         run: |
           ls -la
-          test -f index.html
-          cat index.html
+          test -f ./dist/index.html
 
-      - name: Install tidy & Format index.html
-        run: |
-          sudo apt-get update
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y tidy
-          tidy -q -modify -ashtml index.html || true
 
-      - name: Commit generated page
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -f index.html
-          git diff --cached --quiet || git commit -m "Generate contributors page"
-          git push
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload static file
+        id: statics
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  deploy:
+    environment:
+          name: github-pages
+          url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/generate-page.yaml
+++ b/.github/workflows/generate-page.yaml
@@ -1,0 +1,48 @@
+name: 'Generate Contributors Jobs'
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  if_merged:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: |
+          echo "merging"
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+
+      - name: Install Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.13' 
+
+
+      - name: Generate conrtibutors page
+        run: python generate_page.py
+
+
+      - name: Check generated index.html
+        run: |
+          ls -la
+          test -f index.html
+          cat index.html
+
+      - name: Install tidy & Format index.html
+        run: |
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y tidy
+          tidy -q -modify -ashtml index.html || true
+
+      - name: Commit generated page
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -f index.html
+          git diff --cached --quiet || git commit -m "Generate contributors page"
+          git push

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ target
 out
 out
 gen
+
+index.html

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ target
 out
 out
 gen
+dist
 __
 
 index.html

--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,6 @@ target
 out
 out
 gen
+__
 
 index.html

--- a/generate_page.py
+++ b/generate_page.py
@@ -1,3 +1,8 @@
+"""
+Generate an Contributors Page
+- reading CONTRIBUTORS.md to generate html blocks
+"""
+
 import re
 
 CONTRIBUTORS_PATH = './CONTRIBUTORS.md'
@@ -56,11 +61,18 @@ def create_list_items(contributors):
             f"bg-[{MAIN_COLOR}]/10  inset-ring inset-ring-gray-400/20"
         )
 
-        li = '<li class="relative isolate flex justify-around bg-white h-20 w-80 rounded-lg shadow hover:scale-102 duration-100 ease-in-out">'
-        li +=   f'<a href="{contributor["link"]}" target="_blank" class="flex w-full rounded-md justify-around bg-white">'
+        li = '<li class="relative isolate flex justify-around bg-white h-20 w-80 min-w-80 '
+        li +=   'rounded-lg shadow hover:scale-102 duration-100 ease-in-out">'
+
+        li +=   f'<a href="{contributor["link"]}" target="_blank" class="flex w-full '
+        li +=    'rounded-md justify-around bg-white">'
+
         li +=     '<div class="flex w-full items-center gap-5 p-4">'
         li +=       '<div class="flex w-full gap-4">'
-        li +=           f'<img class="brightness-110 rounded-full h-12 w-12" src="{contributor["avatar"]}" loading="lazy"/>'
+
+        li +=           '<img class="brightness-110 rounded-full h-12 w-12" '
+        li +=           f' src="{contributor["avatar"]}" loading="lazy" alt="Member profile"/>'
+
         li +=           '<div class="flex flex-col justify-center">'
         li +=               '<h2 class="capitalize text-x1 font-bold">'
         li +=                   f'{contributor["handler"]}'
@@ -101,8 +113,12 @@ def create_html_content():
     contributor_count = len(contributor_list_items)
 
     # HTML list content ( ul + li )
-    html_content = f'<span title="Currently {contributor_count} contributors" class="text-sm mb-6 flex justify-center italic text-[{SECONDARY_COLOR}]">({contributor_count})</span>'
-    html_content += '<ul loading="lazy" class="flex flex-wrap gap-1.5 w-fill justify-center">'
+    html_content = (
+        f'<span title="Currently {contributor_count} contributors" '
+        f'class="text-sm mb-6 flex justify-center italic text-[{SECONDARY_COLOR}]"> '
+        f'({contributor_count})</span> '
+        '<ul loading="lazy" class="flex flex-wrap gap-1.5 w-fill justify-center"> '
+    )
     for li in contributor_list_items:
         html_content += li
     html_content += '</ul>'
@@ -125,29 +141,32 @@ def generate_page(index_path = INDEX_PATH):
         ")]"
     )
     base = (
-    '<!DOCTYPE html>'
-    '<html lang="en">'
-    '<head>'
+    '<!DOCTYPE html> '
+    '<html lang="en"> '
+    '<head> '
         '<meta charset="UTF-8">'
-        '<meta name="viewport" content="width=device-width, initial-scale=1.0">'
-        '<link rel="preconnect" href="https://fonts.googleapis.com">'
-        '<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>'
-        '<link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&family=Nunito:ital,wght@0,200..1000;1,200..1000&display=swap" rel="stylesheet">'
-        '<script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>'
-        '<title>Contributors</title>'
-    '</head>'
-    f'<body style="font-family: Nunito" class="text-[{MAIN_COLOR}]">'
-        f'<main class="flex flex-col justify-center {bg_css} max-w-screen px-20 py-50">'
-        f'<h1 class="relative flex justify-center text-6xl font-extrabold text-[{SECONDARY_COLOR}] text-shadow-md" style="font-family: Montserrat">• Contributors •</h1>'
-            '[__CONTENT__]'
-        '</main>'
-    '</body>'
+        '<meta name="viewport" content="width=device-width, initial-scale=1.0"> '
+        '<link rel="preconnect" href="https://fonts.googleapis.com"> '
+        '<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin> '
+        '<link href="https://fonts.googleapis.com/css2'
+        '?family=Montserrat:ital,wght@0,100..900;1,100..900'
+        '&family=Nunito:ital,wght@0,200..1000;1,200..1000&display=swap" rel="stylesheet"> '
+        '<script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script> '
+        '<title>Contributors</title> '
+    '</head> '
+    f'<body style="font-family: Nunito" class="text-[{MAIN_COLOR}]"> '
+        f'<main class="flex flex-col justify-center {bg_css} max-w-screen px-20 py-50"> '
+        f'<h1 class="relative flex justify-center text-6xl font-extrabold text-[{SECONDARY_COLOR}] '
+         'text-shadow-md" style="font-family: Montserrat">• Contributors •</h1> '
+            '[__CONTENT__] '
+        '</main> '
+    '</body> '
     )
 
     contributor_ul = create_html_content()
     base = base.replace(REPLACER, contributor_ul)
 
-    with open(index_path, 'w') as f:
+    with open(index_path, 'w', encoding='utf-8') as f:
         f.write(base)
         f.close()
 

--- a/generate_page.py
+++ b/generate_page.py
@@ -4,9 +4,10 @@ Generate an Contributors Page
 """
 
 import re
+import os
 
 CONTRIBUTORS_PATH = './CONTRIBUTORS.md'
-INDEX_PATH = './index.html'
+INDEX_PATH = './dist/index.html'
 REPLACER = '[__CONTENT__]'
 
 MAIN_COLOR = '#4c0ffb'
@@ -89,15 +90,6 @@ def create_list_items(contributors):
     return list_items
 
 
-def read_index(index_path=INDEX_PATH):
-    '''
-    Reads index file
-    :param index_path: index.html path
-    '''
-    with open(index_path, encoding="utf-8") as f:
-        html = f.read()
-    return html
-
 # Generates content to replace [__CONTENT__] ( with ul, li )
 def create_html_content():
     '''
@@ -172,4 +164,5 @@ def generate_page(index_path = INDEX_PATH):
 
 
 if __name__ == '__main__':
+    os.makedirs(os.path.dirname(INDEX_PATH), exist_ok=True)
     generate_page()

--- a/generate_page.py
+++ b/generate_page.py
@@ -1,0 +1,19 @@
+import re
+CONTRIBUTORS_PATH = './CONTRIBUTORS.md'
+
+# Reads CONTRIBUTORS files and get links only
+def read_contributors_file():
+    with open(CONTRIBUTORS_PATH) as f:
+        text = f.read()
+        contributor_links = re.split(r'[\[\]\(\)\s(\n|\n-)]', text)
+        contributor_links = list(
+            filter(
+                lambda x: len(x) > 1 and x.startswith('https'),
+                contributor_links)
+            )
+        f.close();
+    return contributor_links
+
+
+contributor_links = read_contributors_file()
+print(contributor_links)

--- a/generate_page.py
+++ b/generate_page.py
@@ -14,6 +14,22 @@ def read_contributors_file():
         f.close();
     return contributor_links
 
+# Extract and set contributor info data  ( github handle + link + avatar)
+def create_contributor_data(links):
+    contributors = list()
+    for link in contributor_links:
+        handler = re.split(r'//?', link)[-1]
+        contributor = {
+            'handler': handler,
+            'link': link,
+            'avatar': f'https://github.com/{handler}.png'
+        }
+        contributors.append(contributor)
+    return contributors
+
 
 contributor_links = read_contributors_file()
+contributors = create_contributor_data(contributor_links)
 print(contributor_links)
+print(contributors)
+

--- a/generate_page.py
+++ b/generate_page.py
@@ -27,9 +27,23 @@ def create_contributor_data(links):
         contributors.append(contributor)
     return contributors
 
-
+# Create html list items
+def create_list_items(contributors):
+    list_items = list()
+    for contributor in contributors:
+        li = '<li><div>'
+        li += f'<div><image src="{contributor["avatar"]}"/>'
+        li += f'<h2>{contributor["handler"]}</h2>'
+        li += '<div/>'
+        li += '<div class="separator"></div>'
+        li += '<span class="color-grey-100"></span>'
+        li += '<div/></li>'
+        print(li)
+        list_items.append(li)
+    return list_items
 contributor_links = read_contributors_file()
 contributors = create_contributor_data(contributor_links)
-print(contributor_links)
-print(contributors)
+contributor_list_items = create_list_items(contributors)
+
+print(contributor_list_items)
 

--- a/generate_page.py
+++ b/generate_page.py
@@ -1,9 +1,18 @@
 import re
-CONTRIBUTORS_PATH = './CONTRIBUTORS.md'
 
-# Reads CONTRIBUTORS files and get links only
-def read_contributors_file():
-    with open(CONTRIBUTORS_PATH) as f:
+CONTRIBUTORS_PATH = './CONTRIBUTORS.md'
+INDEX_PATH = './index.html'
+REPLACER = '[__CONTENT__]'
+
+MAIN_COLOR = '#4c0ffb'
+SECONDARY_COLOR = '#c4094d'
+
+# Reads the CONTRIBUTORS.md files
+def read_contributors_file(contributor_path = CONTRIBUTORS_PATH):
+    '''
+    Reads the CONTRIBUTORS.md files
+    '''
+    with open(contributor_path, encoding='utf-8') as f:
         text = f.read()
         contributor_links = re.split(r'[\[\]\(\)\s(\n|\n-)]', text)
         contributor_links = list(
@@ -11,39 +20,137 @@ def read_contributors_file():
                 lambda x: len(x) > 1 and x.startswith('https'),
                 contributor_links)
             )
-        f.close();
+        f.close()
     return contributor_links
 
-# Extract and set contributor info data  ( github handle + link + avatar)
+# Extracts and set contributor info data  ( github handle + link + avatar)
 def create_contributor_data(links):
+    '''
+    Extracts and set contributor info data  ( github handle + link + avatar)
+    :param links: list of string
+    '''
     contributors = list()
-    for link in contributor_links:
-        handler = re.split(r'//?', link)[-1]
+    for link in links:
+        segments = [segment for segment in re.split(r'/', link) if segment]
+        handler = segments[-1]
         contributor = {
             'handler': handler,
             'link': link,
-            'avatar': f'https://github.com/{handler}.png'
+            'avatar': f'https://avatars.githubusercontent.com/{handler}?size=120'
         }
         contributors.append(contributor)
     return contributors
 
 # Create html list items
 def create_list_items(contributors):
+    """
+    Creates html list items
+    :param contributors: list 
+    """
     list_items = list()
     for contributor in contributors:
-        li = '<li><div>'
-        li += f'<div><image src="{contributor["avatar"]}"/>'
-        li += f'<h2>{contributor["handler"]}</h2>'
-        li += '<div/>'
-        li += '<div class="separator"></div>'
-        li += '<span class="color-grey-100"></span>'
-        li += '<div/></li>'
-        print(li)
+        ui_link = "".join(re.split(r'https://|.com|/$', contributor["link"]))
+        badge_css = (
+            "inline-flex items-center rounded-full px-2 py-1 "
+            f"text-xs font-medium text-[{MAIN_COLOR}]/40 "
+            f"bg-[{MAIN_COLOR}]/10  inset-ring inset-ring-gray-400/20"
+        )
+
+        li = '<li class="relative isolate flex justify-around bg-white h-20 w-80 rounded-lg shadow hover:scale-102 duration-100 ease-in-out">'
+        li +=   f'<a href="{contributor["link"]}" target="_blank" class="flex w-full rounded-md justify-around bg-white">'
+        li +=     '<div class="flex w-full items-center gap-5 p-4">'
+        li +=       '<div class="flex w-full gap-4">'
+        li +=           f'<img class="brightness-110 rounded-full h-12 w-12" src="{contributor["avatar"]}" loading="lazy"/>'
+        li +=           '<div class="flex flex-col justify-center">'
+        li +=               '<h2 class="capitalize text-x1 font-bold">'
+        li +=                   f'{contributor["handler"]}'
+        li +=               '</h2>'
+        li +=               f'<span class="{badge_css}">'
+        li +=                   f'{ui_link}'
+        li +=               '</span>'
+        li +=           '</div>'
+        li +=       '</div>'
+        li +=      '</div>'
+        li +=   '</a>'
+        li += '</li>'
         list_items.append(li)
     return list_items
-contributor_links = read_contributors_file()
-contributors = create_contributor_data(contributor_links)
-contributor_list_items = create_list_items(contributors)
 
-print(contributor_list_items)
 
+def read_index(index_path=INDEX_PATH):
+    '''
+    Reads index file
+    :param index_path: index.html path
+    '''
+    with open(index_path, encoding="utf-8") as f:
+        html = f.read()
+    return html
+
+# Generates content to replace [__CONTENT__] ( with ul, li )
+def create_html_content():
+    '''
+    Generates content to replace [__CONTENT__] ( with ul, li )
+    '''
+
+    # Content data
+    contributor_links = read_contributors_file()
+    contributors = create_contributor_data(contributor_links)
+
+    # HTML content creation
+    contributor_list_items = create_list_items(contributors)
+    contributor_count = len(contributor_list_items)
+
+    # HTML list content ( ul + li )
+    html_content = f'<span title="Currently {contributor_count} contributors" class="text-sm mb-6 flex justify-center italic text-[{SECONDARY_COLOR}]">({contributor_count})</span>'
+    html_content += '<ul loading="lazy" class="flex flex-wrap gap-1.5 w-fill justify-center">'
+    for li in contributor_list_items:
+        html_content += li
+    html_content += '</ul>'
+
+    return html_content
+
+# Create page and inject ul and li items
+def generate_page(index_path = INDEX_PATH):
+    '''
+    Create page and inject ul and li items
+    :param index_path: index path for html
+    '''
+    bg_css = (
+        "[background-image:repeating-linear-gradient("
+        "to_bottom_left,"
+        "#090d16_0%,"
+        "#581c87_25%,"
+        "#1e1b4b_50%,"
+        "#090d16_75%"
+        ")]"
+    )
+    base = (
+    '<!DOCTYPE html>'
+    '<html lang="en">'
+    '<head>'
+        '<meta charset="UTF-8">'
+        '<meta name="viewport" content="width=device-width, initial-scale=1.0">'
+        '<link rel="preconnect" href="https://fonts.googleapis.com">'
+        '<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>'
+        '<link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&family=Nunito:ital,wght@0,200..1000;1,200..1000&display=swap" rel="stylesheet">'
+        '<script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>'
+        '<title>Contributors</title>'
+    '</head>'
+    f'<body style="font-family: Nunito" class="text-[{MAIN_COLOR}]">'
+        f'<main class="flex flex-col justify-center {bg_css} max-w-screen px-20 py-50">'
+        f'<h1 class="relative flex justify-center text-6xl font-extrabold text-[{SECONDARY_COLOR}] text-shadow-md" style="font-family: Montserrat">• Contributors •</h1>'
+            '[__CONTENT__]'
+        '</main>'
+    '</body>'
+    )
+
+    contributor_ul = create_html_content()
+    base = base.replace(REPLACER, contributor_ul)
+
+    with open(index_path, 'w') as f:
+        f.write(base)
+        f.close()
+
+
+if __name__ == '__main__':
+    generate_page()


### PR DESCRIPTION
# Contributors Page
**Proposition**: Automate the Visualisation of a  contributors html page.
_Note: Project contribution level for @zero-to-mastery/gitgang_ 
[![Stacks](https://skillicons.dev/icons?i=python,tailwindcss,html)](https://skillicons.dev)
<img width="1220" height="930" alt="image" src="https://github.com/user-attachments/assets/ede95af8-d078-411d-a009-f39e17ad5b82" />


\
Using github-actions, a python script reads the contributors file and generate a list of contributors cards.
Each contributor card displays:
- the user avatar
- the github handle
- le link to the github profile


## Flow
```mermaid
graph TB;
github-workflow[⚙️ Github Action Workflow\n 📃 generate-page.yaml]
contributors[📃 CONTRIBUTORS.md]
index["📃 output: dist/index.html"]
script[📝 generate_page.py]
deployment[📦 Github Pages Deployment]


github-workflow --> script
contributors --> script
script --> index 
index --> deployment
```
 